### PR TITLE
Add Cloud Build configuration for automatic deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# Use Python 3.11 slim image (more stable for Cloud Run)
+FROM python:3.11-slim
+
+# Set working directory
+WORKDIR /app
+
+# Copy requirements file first for better caching
+COPY requirements.txt .
+
+# Install Python dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application files
+COPY . .
+
+# Expose port
+EXPOSE 8080
+
+# Set Streamlit configuration via environment variables
+ENV STREAMLIT_SERVER_PORT=8080
+ENV STREAMLIT_SERVER_ADDRESS=0.0.0.0
+ENV STREAMLIT_SERVER_HEADLESS=true
+ENV STREAMLIT_SERVER_ENABLE_CORS=false
+ENV STREAMLIT_SERVER_ENABLE_XSRF_PROTECTION=true
+
+# Run the application
+CMD ["streamlit", "run", "child_growth_app.py", "--server.port=8080", "--server.address=0.0.0.0"]

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: streamlit run child_growth_app.py --server.port=$PORT --server.address=0.0.0.0 --server.headless=true

--- a/app.yaml
+++ b/app.yaml
@@ -1,9 +1,6 @@
-runtime: python39
+runtime: python
 env: flex
 entrypoint: streamlit run child_growth_app.py --server.port=$PORT --server.address=0.0.0.0
-
-runtime_config:
-  python_version: 3.9
 
 # Automatic scaling configuration
 automatic_scaling:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,47 @@
+# Cloud Build configuration for automatic deployment to Cloud Run
+steps:
+  # Build the container image
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '-t'
+      - 'europe-west1-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/child-growth-tracker:$COMMIT_SHA'
+      - '-t'
+      - 'europe-west1-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/child-growth-tracker:latest'
+      - '.'
+
+  # Push the container image to Artifact Registry
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'push'
+      - 'europe-west1-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/child-growth-tracker:$COMMIT_SHA'
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'push'
+      - 'europe-west1-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/child-growth-tracker:latest'
+
+  # Deploy container image to Cloud Run
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: gcloud
+    args:
+      - 'run'
+      - 'deploy'
+      - 'child-growth-tracker'
+      - '--image'
+      - 'europe-west1-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/child-growth-tracker:$COMMIT_SHA'
+      - '--region'
+      - 'europe-west1'
+      - '--platform'
+      - 'managed'
+      - '--allow-unauthenticated'
+
+images:
+  - 'europe-west1-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/child-growth-tracker:$COMMIT_SHA'
+  - 'europe-west1-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/child-growth-tracker:latest'
+
+options:
+  logging: CLOUD_LOGGING_ONLY
+  machineType: 'E2_HIGHCPU_8'
+
+timeout: '1200s'


### PR DESCRIPTION
## Summary
- Add `cloudbuild.yaml` for Cloud Build CI/CD pipeline that automatically builds and deploys to Cloud Run on every commit to main
- Add `Dockerfile` optimized for Cloud Run deployment (Python 3.11 slim)
- Add `Procfile` for alternative buildpack deployment option
- Update `app.yaml` configuration

## What this enables
This PR enables automatic deployment to Cloud Run whenever code is merged to the main branch. The Cloud Build trigger you set up in GCP Console will now work correctly.

## How it works
1. When code is pushed to main, Cloud Build trigger activates
2. Cloud Build reads `cloudbuild.yaml` and executes the build steps:
   - Builds Docker image using the `Dockerfile`
   - Pushes image to Artifact Registry
   - Deploys the new image to Cloud Run service
3. Service is automatically updated with the latest code

## Test plan
- [x] Created and committed deployment configuration files
- [x] Pushed branch to GitHub
- [ ] Merge PR to main and verify Cloud Build trigger runs successfully
- [ ] Verify service deploys automatically to: https://child-growth-tracker-uxq5rgv44q-ew.a.run.app